### PR TITLE
add one-hop test triples for Text Mining Provider KPs

### DIFF
--- a/onehop/test_triples/KP/Text_Mining_Provider/Text_Mining_CO-OCCURRENCE_API.json
+++ b/onehop/test_triples/KP/Text_Mining_Provider/Text_Mining_CO-OCCURRENCE_API.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://smart-api.info/ui/5be0f321a829792e934545998b9c6afe",
+    "TRAPI": true,
+    "edges": [
+        {
+            "subject_category": "biolink:Disease",
+            "object_category": "biolink:AnatomicalEntity",
+            "predicate": "biolink:related_to",
+            "subject": "MONDO:0004315",
+            "object": "UBERON:0000126"
+        }
+    ]
+}

--- a/onehop/test_triples/KP/Text_Mining_Provider/Text_Mining_Targeted_Association_API.json
+++ b/onehop/test_triples/KP/Text_Mining_Provider/Text_Mining_Targeted_Association_API.json
@@ -1,0 +1,20 @@
+{
+    "url": "https://smart-api.info/ui/978fe380a147a8641caf72320862697b",
+    "TRAPI": true,
+    "edges": [
+        {
+            "subject_category": "biolink:ChemicalSubstance",
+            "object_category": "biolink:GeneOrGeneProduct",
+            "predicate": "biolink:negatively_regulates_entity_to_entity",
+            "subject": "CHEBI:3215",
+            "object": "PR:000031567"
+        },
+        {
+            "subject_category": "biolink:ChemicalSubstance",
+            "object_category": "biolink:GeneOrGeneProduct",
+            "predicate": "biolink:positively_regulates_entity_to_entity",
+            "subject": "CHEBI:16474",
+            "object": "PR:000003847"
+        }
+    ]
+}


### PR DESCRIPTION
This PR includes test triples for both Text Mining Provider KP to be used in the one-hop tests.

Note that only one example triple has been included for the cooccurrence KP. In the future we can programmatically add all possible combinations of subject-object categories (they all use the same relation -- biolink:related_to) if that is desired.